### PR TITLE
Add passport-based auth options

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,3 +22,36 @@ For building the backend you can run the following command:
 npm install
 npm run build
 ```
+
+## Authentication
+
+The backend supports three authentication modes selected through the `AUTH_MODE` environment variable:
+
+* `basic` - default HTTP Basic authentication.
+* `oidc` - OpenID Connect using `passport-openidconnect`.
+* `saml` - SAML 2.0 using `passport-saml`.
+
+Depending on the chosen mode, additional environment variables are required:
+
+### OIDC variables
+
+```
+OIDC_ISSUER_URL      Issuer identifier
+OIDC_AUTH_URL        Authorization endpoint
+OIDC_TOKEN_URL       Token endpoint
+OIDC_USERINFO_URL    User info endpoint
+OIDC_CLIENT_ID       Client identifier
+OIDC_CLIENT_SECRET   Client secret
+OIDC_CALLBACK_URL    Callback URL used by the application
+```
+
+### SAML variables
+
+```
+SAML_ENTRY_POINT   Identity provider entry point URL
+SAML_ISSUER        Issuer string for this service
+SAML_CALLBACK_URL  Assertion consumer service URL
+SAML_CERT          Identity provider certificate
+```
+
+OIDC and SAML strategies expose their login callbacks at `/call/api/auth/oidc/callback` and `/call/api/auth/saml/callback` respectively.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,9 @@
 				"express": "4.21.2",
 				"express-basic-auth": "1.2.1",
 				"livekit-server-sdk": "2.9.7",
+				"passport": "0.7.0",
+				"passport-openidconnect": "0.1.2",
+				"passport-saml": "3.2.4",
 				"winston": "3.17.0"
 			},
 			"devDependencies": {
@@ -24,6 +27,9 @@
 				"@types/cors": "2.8.17",
 				"@types/express": "4.17.21",
 				"@types/node": "20.17.16",
+				"@types/passport": "^1.0.17",
+				"@types/passport-openidconnect": "^0.1.3",
+				"@types/passport-saml": "^1.1.7",
 				"@typescript-eslint/eslint-plugin": "6.7.5",
 				"@typescript-eslint/parser": "6.7.5",
 				"cross-env": "7.0.3",
@@ -2188,6 +2194,61 @@
 				"undici-types": "~6.19.2"
 			}
 		},
+		"node_modules/@types/oauth": {
+			"version": "0.9.6",
+			"resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.6.tgz",
+			"integrity": "sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/passport": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+			"integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*"
+			}
+		},
+		"node_modules/@types/passport-openidconnect": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@types/passport-openidconnect/-/passport-openidconnect-0.1.3.tgz",
+			"integrity": "sha512-k1Ni7bG/9OZNo2Qpjg2W6GajL+pww6ZPaNWMXfpteCX4dXf4QgaZLt2hjR5IiPrqwBT9+W8KjCTJ/uhGIoBx/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*",
+				"@types/oauth": "*",
+				"@types/passport": "*",
+				"@types/passport-strategy": "*"
+			}
+		},
+		"node_modules/@types/passport-saml": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@types/passport-saml/-/passport-saml-1.1.7.tgz",
+			"integrity": "sha512-pMKJvWlS06ZGXtWVbfULSYDYv9XlvDBhCmzkbuYOqfeVqfpgr2SJKRKvAZ3RK0TzNE2vO67WRSnMbPPz68TyEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*",
+				"@types/passport": "*"
+			}
+		},
+		"node_modules/@types/passport-strategy": {
+			"version": "0.2.38",
+			"resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+			"integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*",
+				"@types/passport": "*"
+			}
+		},
 		"node_modules/@types/qs": {
 			"version": "6.9.18",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -2455,6 +2516,16 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.7.13",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+			"integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+			"deprecated": "this version is no longer supported, please update to at least 0.8.*",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -4407,6 +4478,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/oauth": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+			"integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+			"license": "MIT"
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4531,6 +4608,68 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/passport": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+			"integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"passport-strategy": "1.x.x",
+				"pause": "0.0.1",
+				"utils-merge": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jaredhanson"
+			}
+		},
+		"node_modules/passport-openidconnect": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/passport-openidconnect/-/passport-openidconnect-0.1.2.tgz",
+			"integrity": "sha512-JX3rTyW+KFZ/E9OF/IpXJPbyLO9vGzcmXB5FgSP2jfL3LGKJPdV7zUE8rWeKeeI/iueQggOeFa3onrCmhxXZTg==",
+			"license": "MIT",
+			"dependencies": {
+				"oauth": "0.10.x",
+				"passport-strategy": "1.x.x"
+			},
+			"engines": {
+				"node": ">= 0.6.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jaredhanson"
+			}
+		},
+		"node_modules/passport-saml": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/passport-saml/-/passport-saml-3.2.4.tgz",
+			"integrity": "sha512-JSgkFXeaexLNQh1RrOvJAgjLnZzH/S3HbX/mWAk+i7aulnjqUe7WKnPl1NPnJWqP7Dqsv0I2Xm6KIFHkftk0HA==",
+			"deprecated": "For versions >= 4, please use scopped package @node-saml/passport-saml",
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.7.6",
+				"debug": "^4.3.2",
+				"passport-strategy": "^1.0.0",
+				"xml-crypto": "^2.1.3",
+				"xml-encryption": "^2.0.0",
+				"xml2js": "^0.4.23",
+				"xmlbuilder": "^15.1.1"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/passport-strategy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+			"integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4576,6 +4715,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/pause": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+			"integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -4841,6 +4985,12 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+			"license": "ISC"
 		},
 		"node_modules/semver": {
 			"version": "7.7.1",
@@ -5438,6 +5588,73 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/xml-crypto": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.6.tgz",
+			"integrity": "sha512-jjvpO8vHNV8QFhW5bMypP+k4BjBqHe/HrpIwpPcdUnUTIJakSIuN96o3Sdah4tKu2z64kM/JHEH8iEHGCc6Gyw==",
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.7.9",
+				"xpath": "0.0.32"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/xml-encryption": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+			"integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.7.0",
+				"escape-html": "^1.0.3",
+				"xpath": "0.0.32"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xml2js/node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+			"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/xpath": {
+			"version": "0.0.32",
+			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+			"integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.0"
+			}
 		},
 		"node_modules/yn": {
 			"version": "3.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,9 @@
 		"express": "4.21.2",
 		"express-basic-auth": "1.2.1",
 		"livekit-server-sdk": "2.9.7",
+		"passport": "0.7.0",
+		"passport-openidconnect": "0.1.2",
+		"passport-saml": "3.2.4",
 		"winston": "3.17.0"
 	},
 	"devDependencies": {
@@ -44,6 +47,9 @@
 		"@types/cors": "2.8.17",
 		"@types/express": "4.17.21",
 		"@types/node": "20.17.16",
+		"@types/passport": "^1.0.17",
+		"@types/passport-openidconnect": "^0.1.3",
+		"@types/passport-saml": "^1.1.7",
 		"@typescript-eslint/eslint-plugin": "6.7.5",
 		"@typescript-eslint/parser": "6.7.5",
 		"cross-env": "7.0.3",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -16,6 +16,20 @@ export const CALL_SECRET = process.env.CALL_SECRET || 'user';
 export const CALL_ADMIN_USER = process.env.CALL_ADMIN_USER || 'admin';
 export const CALL_ADMIN_SECRET = process.env.CALL_ADMIN_SECRET || 'admin';
 
+// Authentication configuration
+export const AUTH_MODE = process.env.AUTH_MODE || 'basic';
+export const OIDC_ISSUER_URL = process.env.OIDC_ISSUER_URL || '';
+export const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID || '';
+export const OIDC_CLIENT_SECRET = process.env.OIDC_CLIENT_SECRET || '';
+export const OIDC_CALLBACK_URL = process.env.OIDC_CALLBACK_URL || '';
+export const OIDC_AUTH_URL = process.env.OIDC_AUTH_URL || '';
+export const OIDC_TOKEN_URL = process.env.OIDC_TOKEN_URL || '';
+export const OIDC_USERINFO_URL = process.env.OIDC_USERINFO_URL || '';
+export const SAML_ENTRY_POINT = process.env.SAML_ENTRY_POINT || '';
+export const SAML_ISSUER = process.env.SAML_ISSUER || '';
+export const SAML_CALLBACK_URL = process.env.SAML_CALLBACK_URL || '';
+export const SAML_CERT = process.env.SAML_CERT || '';
+
 /**
  * Log levels configuration: error, warn, info, verbose, debug, silly
  *

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import passport from 'passport';
 import { AuthService } from '../services/auth.service.js';
 import { LoggerService } from '../services/logger.service.js';
 
@@ -49,5 +50,13 @@ export const adminLogin = (req: Request, res: Response) => {
 };
 
 export const adminLogout = (req: Request, res: Response) => {
-	return res.status(200).json({ message: 'Logout successful' });
+        return res.status(200).json({ message: 'Logout successful' });
 };
+
+export const oidcCallback = passport.authenticate('openidconnect', {
+        session: false
+});
+
+export const samlCallback = passport.authenticate('saml', {
+        session: false
+});

--- a/backend/src/controllers/config.controller.ts
+++ b/backend/src/controllers/config.controller.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express';
-import { CALL_PRIVATE_ACCESS } from '../config.js';
+import { CALL_PRIVATE_ACCESS, AUTH_MODE } from '../config.js';
 import { LoggerService } from '../services/logger.service.js';
 
 const logger = LoggerService.getInstance();
 
 export const getConfig = async (req: Request, res: Response) => {
 	logger.verbose('Getting config');
-	const response = { isPrivateAccess: CALL_PRIVATE_ACCESS === 'true' };
+        const response = { isPrivateAccess: CALL_PRIVATE_ACCESS === 'true', authMode: AUTH_MODE };
 	return res.status(200).json(response);
 };

--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -6,7 +6,9 @@ import * as broadcastCtrl from '../controllers/broadcasting.controller.js';
 import * as authCtrl from '../controllers/auth.controller.js';
 import { getConfig } from '../controllers/config.controller.js';
 import { healthCheck } from '../controllers/healthcheck.controller.js';
-import { withAdminAndUserBasicAuth, withAdminBasicAuth, withUserBasicAuth } from '../services/auth.service.js';
+import { AuthStrategyService } from '../services/index.js';
+
+const authStrategy = AuthStrategyService.getInstance();
 
 const apiRouter = Router();
 
@@ -14,31 +16,33 @@ apiRouter.use(bodyParser.urlencoded({ extended: true }));
 apiRouter.use(bodyParser.json());
 
 // Room Routes
-apiRouter.post('/rooms', withUserBasicAuth, roomCtrl.createRoom);
+apiRouter.post('/rooms', authStrategy.userAuth(), roomCtrl.createRoom);
 
 // Recording Routes
-apiRouter.post('/recordings', withUserBasicAuth, recordingCtrl.startRecording);
-apiRouter.put('/recordings/:recordingId', withUserBasicAuth, recordingCtrl.stopRecording);
+apiRouter.post('/recordings', authStrategy.userAuth(), recordingCtrl.startRecording);
+apiRouter.put('/recordings/:recordingId', authStrategy.userAuth(), recordingCtrl.stopRecording);
 apiRouter.get('/recordings/:recordingId/stream', recordingCtrl.streamRecording);
-apiRouter.delete('/recordings/:recordingId', withUserBasicAuth, recordingCtrl.deleteRecording);
+apiRouter.delete('/recordings/:recordingId', authStrategy.userAuth(), recordingCtrl.deleteRecording);
 
-apiRouter.get('/admin/recordings', withAdminBasicAuth, recordingCtrl.getAllRecordings);
-apiRouter.delete('/admin/recordings/:recordingId', withAdminBasicAuth, recordingCtrl.deleteRecording);
+apiRouter.get('/admin/recordings', authStrategy.adminAuth(), recordingCtrl.getAllRecordings);
+apiRouter.delete('/admin/recordings/:recordingId', authStrategy.adminAuth(), recordingCtrl.deleteRecording);
 
 // Broadcasting Routes
-apiRouter.post('/broadcasts', withUserBasicAuth, broadcastCtrl.startBroadcasting);
-apiRouter.put('/broadcasts/:broadcastId', withUserBasicAuth, broadcastCtrl.stopBroadcasting);
+apiRouter.post('/broadcasts', authStrategy.userAuth(), broadcastCtrl.startBroadcasting);
+apiRouter.put('/broadcasts/:broadcastId', authStrategy.userAuth(), broadcastCtrl.stopBroadcasting);
 
 // Auth Routes
 apiRouter.post('/login', authCtrl.login);
 apiRouter.post('/logout', authCtrl.logout);
 apiRouter.post('/admin/login', authCtrl.adminLogin);
 apiRouter.post('/admin/logout', authCtrl.adminLogout);
+apiRouter.get('/auth/oidc/callback', authCtrl.oidcCallback);
+apiRouter.post('/auth/saml/callback', authCtrl.samlCallback);
 
 // Config Routes
 apiRouter.get('/config', getConfig);
 
 // Health Check Route
-apiRouter.get('/healthcheck', withAdminAndUserBasicAuth, healthCheck);
+apiRouter.get('/healthcheck', authStrategy.userOrAdminAuth(), healthCheck);
 
 export { apiRouter };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { apiRouter, livekitRouter } from './routes/index.js';
+import { AuthStrategyService } from './services/index.js';
 import chalk from 'chalk';
 import {
 	LIVEKIT_URL,
@@ -35,7 +36,10 @@ import {
 } from './config.js';
 
 const createApp = () => {
-	const app = express();
+        const app = express();
+
+        const authStrategyService = AuthStrategyService.getInstance();
+        authStrategyService.configure(app);
 
 	// Enable CORS support
 	if (SERVER_CORS_ORIGIN) {

--- a/backend/src/services/auth-strategy.service.ts
+++ b/backend/src/services/auth-strategy.service.ts
@@ -1,0 +1,135 @@
+import { Application, RequestHandler } from 'express';
+import passport from 'passport';
+import { Strategy as OIDCStrategy } from 'passport-openidconnect';
+import { Strategy as SamlStrategy } from 'passport-saml';
+import basicAuth from 'express-basic-auth';
+import {
+  AUTH_MODE,
+  OIDC_CALLBACK_URL,
+  OIDC_CLIENT_ID,
+  OIDC_CLIENT_SECRET,
+  OIDC_ISSUER_URL,
+  OIDC_AUTH_URL,
+  OIDC_TOKEN_URL,
+  OIDC_USERINFO_URL,
+  SAML_CALLBACK_URL,
+  SAML_ENTRY_POINT,
+  SAML_ISSUER,
+  SAML_CERT,
+  CALL_PRIVATE_ACCESS,
+  CALL_USER,
+  CALL_SECRET,
+  CALL_ADMIN_USER,
+  CALL_ADMIN_SECRET,
+} from '../config.js';
+
+export class AuthStrategyService {
+  private static instance: AuthStrategyService;
+
+  static getInstance(): AuthStrategyService {
+    if (!this.instance) {
+      this.instance = new AuthStrategyService();
+    }
+    return this.instance;
+  }
+
+  /**
+   * Configure passport strategies and register initialization middleware.
+   */
+  configure(app: Application) {
+    if (AUTH_MODE === 'oidc') {
+      passport.use(
+        new OIDCStrategy(
+          {
+            issuer: OIDC_ISSUER_URL,
+            authorizationURL: OIDC_AUTH_URL,
+            tokenURL: OIDC_TOKEN_URL,
+            userInfoURL: OIDC_USERINFO_URL,
+            clientID: OIDC_CLIENT_ID,
+            clientSecret: OIDC_CLIENT_SECRET,
+            callbackURL: OIDC_CALLBACK_URL,
+          } as any,
+          (_issuer: string, profile: any, done: any) => {
+            return done(null, profile);
+          },
+        ),
+      );
+    } else if (AUTH_MODE === 'saml') {
+      passport.use(
+        new SamlStrategy(
+          {
+            entryPoint: SAML_ENTRY_POINT,
+            issuer: SAML_ISSUER,
+            callbackUrl: SAML_CALLBACK_URL,
+            cert: SAML_CERT,
+          },
+          (profile: any, done: any) => {
+            return done(null, profile);
+          },
+        ),
+      );
+    }
+
+    if (AUTH_MODE !== 'basic') {
+      app.use(passport.initialize());
+    }
+  }
+
+  /** Generic user authentication middleware */
+  userAuth(): RequestHandler {
+    if (AUTH_MODE === 'basic') {
+      return (req, res, next) => {
+        if (CALL_PRIVATE_ACCESS === 'true') {
+          const middleware = basicAuth({
+            users: { [CALL_USER]: CALL_SECRET },
+            challenge: true,
+            unauthorizedResponse: () => 'Unauthorized',
+          });
+          return middleware(req, res, next);
+        }
+        return next();
+      };
+    }
+
+    const strategy = AUTH_MODE === 'oidc' ? 'openidconnect' : 'saml';
+    return passport.authenticate(strategy, { session: false });
+  }
+
+  /** Admin authentication middleware */
+  adminAuth(): RequestHandler {
+    if (AUTH_MODE === 'basic') {
+      return basicAuth({
+        users: { [CALL_ADMIN_USER]: CALL_ADMIN_SECRET },
+        challenge: true,
+        unauthorizedResponse: () => 'Unauthorized',
+      });
+    }
+
+    // In OIDC/SAML modes there is no distinction
+    const strategy = AUTH_MODE === 'oidc' ? 'openidconnect' : 'saml';
+    return passport.authenticate(strategy, { session: false });
+  }
+
+  /** Middleware allowing either user or admin credentials */
+  userOrAdminAuth(): RequestHandler {
+    if (AUTH_MODE === 'basic') {
+      return (req, res, next) => {
+        if (CALL_PRIVATE_ACCESS === 'true') {
+          const middleware = basicAuth({
+            users: {
+              [CALL_USER]: CALL_SECRET,
+              [CALL_ADMIN_USER]: CALL_ADMIN_SECRET,
+            },
+            challenge: true,
+            unauthorizedResponse: () => 'Unauthorized',
+          });
+          return middleware(req, res, next);
+        }
+        return next();
+      };
+    }
+
+    const strategy = AUTH_MODE === 'oidc' ? 'openidconnect' : 'saml';
+    return passport.authenticate(strategy, { session: false });
+  }
+}

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import basicAuth from 'express-basic-auth';
-import { CALL_ADMIN_SECRET, CALL_ADMIN_USER, CALL_PRIVATE_ACCESS, CALL_SECRET, CALL_USER } from '../config.js';
+import { AUTH_MODE, CALL_ADMIN_SECRET, CALL_ADMIN_USER, CALL_PRIVATE_ACCESS, CALL_SECRET, CALL_USER } from '../config.js';
 
 // Configure basic auth middleware for user and admin access
 export const withAdminAndUserBasicAuth = (req: Request, res: Response, next: NextFunction) => {
@@ -61,15 +61,19 @@ export class AuthService {
 		return AuthService.instance;
 	}
 
-	authenticateUser(username: string, password: string): boolean {
-		if (CALL_PRIVATE_ACCESS === 'true') {
-			return username === CALL_USER && password === CALL_SECRET;
-		}
+        authenticateUser(username: string, password: string): boolean {
+                if (AUTH_MODE === 'basic' && CALL_PRIVATE_ACCESS === 'true') {
+                        return username === CALL_USER && password === CALL_SECRET;
+                }
 
-		return true;
-	}
+                return true;
+        }
 
-	authenticateAdmin(username: string, password: string): boolean {
-		return username === CALL_ADMIN_USER && password === CALL_ADMIN_SECRET;
-	}
+        authenticateAdmin(username: string, password: string): boolean {
+                if (AUTH_MODE === 'basic') {
+                        return username === CALL_ADMIN_USER && password === CALL_ADMIN_SECRET;
+                }
+
+                return true;
+        }
 }

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -8,3 +8,4 @@ export * from './s3.service.js';
 export * from './webhook.service.js';
 export * from './azure-blob-wrapper.service.js';
 export * from './IStorage.service.js';
+export * from './auth-strategy.service.js';

--- a/frontend/src/app/models/server.model.ts
+++ b/frontend/src/app/models/server.model.ts
@@ -1,4 +1,4 @@
 export interface ServerConfigurationResponse {
-	isPrivateAccess: boolean;
-
+        isPrivateAccess: boolean;
+        authMode?: string;
 }

--- a/frontend/src/app/services/config.service.ts
+++ b/frontend/src/app/services/config.service.ts
@@ -25,16 +25,24 @@ export class ConfigService {
 		} catch (error) {
 			console.error('Failed to load configuration:', error);
 			// Handle the error as needed, e.g., set default config or notify the user
-			this.config = { isPrivateAccess: true }; // Default value in case of error
+                        this.config = { isPrivateAccess: true, authMode: 'basic' }; // Default value in case of error
 		}
 	}
 
-	isPrivateAccess(): boolean {
+        isPrivateAccess(): boolean {
 		// Ensure configuration is loaded before accessing it
 		if (!this.initialization) {
 			throw new Error('ConfigService not initialized. Call initialize() before accessing config.');
 		}
 
-		return this.config?.isPrivateAccess ?? true;
-	}
+                return this.config?.isPrivateAccess ?? true;
+        }
+
+        getAuthMode(): string {
+                if (!this.initialization) {
+                        throw new Error('ConfigService not initialized. Call initialize() before accessing config.');
+                }
+
+                return this.config?.authMode ?? 'basic';
+        }
 }

--- a/frontend/src/app/services/http.service.ts
+++ b/frontend/src/app/services/http.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { RecordingInfo } from 'openvidu-components-angular';
 import { lastValueFrom } from 'rxjs';
 import { StorageAppService } from '@services/storage.service';
+import { ConfigService } from '@services/config.service';
 
 @Injectable({
 	providedIn: 'root'
@@ -11,10 +12,11 @@ export class HttpService {
 	// private baseHref: string;
 	private pathPrefix = 'call/api';
 
-	constructor(
-		private http: HttpClient,
-		private storageService: StorageAppService
-	) {
+        constructor(
+                private http: HttpClient,
+                private storageService: StorageAppService,
+                private configService: ConfigService
+        ) {
 		// this.baseHref = '/' + (!!window.location.pathname.split('/')[1] ? window.location.pathname.split('/')[1] + '/' : '');
 	}
 
@@ -22,14 +24,16 @@ export class HttpService {
 		const headers = new HttpHeaders({
 			'Content-Type': 'application/json'
 		});
-		const userCredentials = this.storageService.getParticipantCredentials();
+                if (this.configService.getAuthMode() === 'basic') {
+                        const userCredentials = this.storageService.getParticipantCredentials();
 
-		if (userCredentials?.username && userCredentials?.password) {
-			return headers.append(
-				'Authorization',
-				`Basic ${btoa(`${userCredentials.username}:${userCredentials.password}`)}`
-			);
-		}
+                        if (userCredentials?.username && userCredentials?.password) {
+                                return headers.append(
+                                        'Authorization',
+                                        `Basic ${btoa(`${userCredentials.username}:${userCredentials.password}`)}`
+                                );
+                        }
+                }
 
 		return headers;
 	}
@@ -38,18 +42,20 @@ export class HttpService {
 		const headers = new HttpHeaders({
 			'Content-Type': 'application/json'
 		});
-		const adminCredentials = this.storageService.getAdminCredentials();
+                if (this.configService.getAuthMode() === 'basic') {
+                        const adminCredentials = this.storageService.getAdminCredentials();
 
-		if (!adminCredentials) {
-			console.error('Admin credentials not found');
-			return headers;
-		}
+                        if (!adminCredentials) {
+                                console.error('Admin credentials not found');
+                                return headers;
+                        }
 
-		const { username, password } = adminCredentials;
+                        const { username, password } = adminCredentials;
 
-		if (username && password) {
-			return headers.set('Authorization', `Basic ${btoa(`${username}:${password}`)}`);
-		}
+                        if (username && password) {
+                                return headers.set('Authorization', `Basic ${btoa(`${username}:${password}`)}`);
+                        }
+                }
 
 		return headers;
 	}


### PR DESCRIPTION
## Summary
- add new dependencies for OIDC and SAML
- implement `AuthStrategyService` for basic/OIDC/SAML strategies
- configure express server to use the new service
- expose new callback endpoints
- handle auth mode in config response and frontend services
- document new environment variables

## Testing
- `npm run build` in `backend`
- `npx ng build --configuration production` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6872f22d6cb0832e8109e2d27e0aa7ea